### PR TITLE
refactor: skip packages that depend on autoware_cuda_dependency_meta (20250218)

### DIFF
--- a/.github/workflows/generate-deb-packages-aws.yaml
+++ b/.github/workflows/generate-deb-packages-aws.yaml
@@ -70,6 +70,7 @@ jobs:
           SQUASH_HISTORY: true
           PACKAGES_BRANCH: jammy-humble-main
           GIT_LFS: true
+          SKIP_PACKAGES: autoware_cuda_dependency_meta autoware_cuda_utils autoware_bytetrack autoware_cuda_dependency_meta autoware_cuda_utils autoware_default_adapi autoware_detection_by_tracker autoware_diagnostic_graph_utils autoware_hazard_status_converter autoware_image_projection_based_fusion autoware_launch autoware_lidar_apollo_instance_segmentation autoware_lidar_centerpoint autoware_lidar_transfusion autoware_livox_tag_filter autoware_probabilistic_occupancy_grid_map autoware_shape_estimation autoware_tensorrt_classifier autoware_tensorrt_common autoware_tensorrt_yolox autoware_traffic_light_classifier autoware_traffic_light_fine_detector tier4_autoware_api_launch tier4_perception_launch trt_batched_nms
   stop-runner:
     name: "Stop self-hosted EC2 runner"
     needs:

--- a/sources.repos
+++ b/sources.repos
@@ -73,8 +73,8 @@ repositories:
     version: da146226cc681a0008f30ade5b02257cea2bab05
   universe/autoware.universe:
     type: git
-    url: https://github.com/autowarefoundation/autoware.universe.git
-    version: c9aa4093433f4e573c0898b393a5e98f883bdab7
+    url: https://github.com/esteve/autoware.universe.git
+    version: d2f96cf7e119a59dbc0191fb89dfd5971328e79e
   universe/external/eagleye:
     type: git
     url: https://github.com/MapIV/eagleye.git

--- a/sources.repos
+++ b/sources.repos
@@ -74,7 +74,7 @@ repositories:
   universe/autoware.universe:
     type: git
     url: https://github.com/esteve/autoware.universe.git
-    version: d2f96cf7e119a59dbc0191fb89dfd5971328e79e
+    version: 91e7ad20ab50491ab7d39a750a6e2a15d9296daf
   universe/external/eagleye:
     type: git
     url: https://github.com/MapIV/eagleye.git

--- a/sources.repos
+++ b/sources.repos
@@ -2,11 +2,11 @@ repositories:
   core/autoware.core:
     type: git
     url: https://github.com/autowarefoundation/autoware.core.git
-    version: 3f26d5245f5c161fc255a8c707cfdaca5c7c9710
+    version: 3a595e4f115309d45cd9f5b1b4821f8a07ab3926
   core/autoware_adapi_msgs:
     type: git
     url: https://github.com/autowarefoundation/autoware_adapi_msgs.git
-    version: f895313b0ecad49477b07ea53c0f625670cbc482
+    version: 7c2e79e3b50eeec857a4e5c9e6bfe343245de5b4
   core/autoware_cmake:
     type: git
     url: https://github.com/autowarefoundation/autoware_cmake.git
@@ -26,11 +26,11 @@ repositories:
   core/autoware_utils:
     type: git
     url: https://github.com/autowarefoundation/autoware_utils.git
-    version: 451419ec58923b1a1035956f838afdb8d3cbc0d3
+    version: 7115d01f3f8b7b0abc31dfabdd293ce548399623
   launcher/autoware_launch:
     type: git
     url: https://github.com/autowarefoundation/autoware_launch.git
-    version: 19d30d4a681aa12cae72b23958279e286959b3ab
+    version: caed5fd7576f2c348517fa5734e2c19a09b80f65
   param/autoware_individual_params:
     type: git
     url: https://github.com/autowarefoundation/autoware_individual_params.git
@@ -58,23 +58,23 @@ repositories:
   sensor_kit/awsim_labs_sensor_kit_launch:
     type: git
     url: https://github.com/autowarefoundation/awsim_labs_sensor_kit_launch.git
-    version: 01570ac6b5e748efdfb0e58d0fcb544b1c34b160
+    version: 6a5b128b529a6e766a7f2566f84e3f7296009bd8
   sensor_kit/external/awsim_sensor_kit_launch:
     type: git
     url: https://github.com/tier4/awsim_sensor_kit_launch.git
-    version: 33ef7eec8951c6466cb2c12209275e59837f3a3e
+    version: e501dfb504eff739920f8495e46ed408907859df
   sensor_kit/sample_sensor_kit_launch:
     type: git
     url: https://github.com/autowarefoundation/sample_sensor_kit_launch.git
-    version: f0b6ef48c08885377e18565e56a3820a907d7f76
+    version: 10425283cc1dddd1f05a1478c96d48aad726bfd4
   sensor_kit/single_lidar_sensor_kit_launch:
     type: git
     url: https://github.com/autowarefoundation/single_lidar_sensor_kit_launch.git
-    version: df12295d27bd2b7b2ed8c70502a3223471fab135
+    version: da146226cc681a0008f30ade5b02257cea2bab05
   universe/autoware.universe:
     type: git
     url: https://github.com/autowarefoundation/autoware.universe.git
-    version: b3c69b465c34e155f6a95f9656d4f4dc7bcb2ecd
+    version: c9aa4093433f4e573c0898b393a5e98f883bdab7
   universe/external/eagleye:
     type: git
     url: https://github.com/MapIV/eagleye.git
@@ -106,7 +106,7 @@ repositories:
   universe/external/tier4_ad_api_adaptor:
     type: git
     url: https://github.com/tier4/tier4_ad_api_adaptor.git
-    version: 4dbe2eda72c637215c38ec1c1562d2a979b37565
+    version: 278e32d1bc3f14cb79e27c6ef8131db82504769d
   universe/external/tier4_autoware_msgs:
     type: git
     url: https://github.com/tier4/tier4_autoware_msgs.git


### PR DESCRIPTION
Based on #124 