### PR TITLE
feat: use self-hosted machines

### DIFF
--- a/.github/workflows/generate-deb-packages-aws.yaml
+++ b/.github/workflows/generate-deb-packages-aws.yaml
@@ -9,38 +9,15 @@ on:
     branches:
       - 'main'
 
+concurrency:
+  group: generate-deb-packages # only one job can run at a time
+  cancel-in-progress: true
+
 jobs:
-  start-runner:
-    name: "Start self-hosted EC2 runner"
-    runs-on: ubuntu-latest
-    outputs:
-      label: ${{ steps.start-ec2-runner.outputs.label }}
-      ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
-    steps:
-      - name: "Configure AWS credentials"
-        uses: aws-actions/configure-aws-credentials@v2
-        with:
-          aws-access-key-id: ${{ secrets.EC2_ON_DEMAND_AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.EC2_ON_DEMAND_AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ secrets.EC2_ON_DEMAND_AWS_REGION }}
-      - name: "Start EC2 runner"
-        id: start-ec2-runner
-        uses: esteve/ec2-github-runner@feature/allow-changing-root-volume-size
-        with:
-          mode: start
-          github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN_MFC }}
-          ec2-image-id: ami-0c3b809fcf2445b6a
-          ec2-instance-type: t3.xlarge
-          ec2-volume-size: 40
-          ec2-volume-type: gp3
-          subnet-id: subnet-4e5eb225
-          security-group-id: sg-02780d120ee4d06e1
-          run-runner-as-service: true
-          run-runner-as-user: ubuntu
   generate-deb-packages-aws:
     name: "Build Debian packages for Autoware (Humble)"
-    needs: start-runner
-    runs-on: ${{ needs.start-runner.outputs.label }}
+    runs-on: [self-hosted, Linux, X64]
+    container: ubuntu:22.04
     timeout-minutes: 5760
     permissions:
       deployments: write
@@ -87,25 +64,3 @@ jobs:
           if-no-files-found: error
           retention-days: 1
           compression-level: 0
-
-  stop-runner:
-    name: "Stop self-hosted EC2 runner"
-    needs:
-      - start-runner
-      - generate-deb-packages-aws
-    runs-on: ubuntu-latest
-    if: ${{ always() }}
-    steps:
-      - name: "Configure AWS credentials"
-        uses: aws-actions/configure-aws-credentials@v2
-        with:
-          aws-access-key-id: ${{ secrets.EC2_ON_DEMAND_AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.EC2_ON_DEMAND_AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ secrets.EC2_ON_DEMAND_AWS_REGION }}
-      - name: "Stop EC2 runner"
-        uses: machulav/ec2-github-runner@v2
-        with:
-          mode: stop
-          github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN_MFC }}
-          label: ${{ needs.start-runner.outputs.label }}
-          ec2-instance-id: ${{ needs.start-runner.outputs.ec2-instance-id }}

--- a/.github/workflows/generate-deb-packages-aws.yaml
+++ b/.github/workflows/generate-deb-packages-aws.yaml
@@ -16,8 +16,7 @@ concurrency:
 jobs:
   generate-deb-packages-aws:
     name: "Build Debian packages for Autoware (Humble)"
-    runs-on: [self-hosted, Linux, X64]
-    container: ubuntu:22.04
+    runs-on: [self-hosted, Linux, X64, generate-deb-pkgs]
     timeout-minutes: 5760
     permissions:
       deployments: write


### PR DESCRIPTION
- I've added concurrency option to make sure only one instance can be run at a time.
   - Since it can be run at any one of the 9 self hosted machines, this will make sure it is using only 1 machine at a time.
      - 🔴 Actually this can be removed since we now have dedicated a single machine for this workflow.
   - Made `cancel-in-progress` true but you might want to make it false to avoid cancelling an ongoing run by mistake.
   - More info can be found at: https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/control-the-concurrency-of-workflows-and-jobs
- Our runners can be found here: https://github.com/organizations/autowarefoundation/settings/actions/runners
- Removed `start-runner:` and `stop-runner:` jobs since they are no longer relevant.
- Uses `self-hosted, Linux, X64, generate-deb-pkgs` labels, especially `generate-deb-pkgs` label to not use the other machines.

Feel free to modify this PR as you wish!